### PR TITLE
Added ADC definitions from the datasheet

### DIFF
--- a/patches/EMW3162/platform.c
+++ b/patches/EMW3162/platform.c
@@ -112,12 +112,19 @@ const platform_gpio_t platform_gpio_pins[] =
 };
 
 /* ADC peripherals. Used WICED/platform/MCU/wiced_platform_common.c */
-// const platform_adc_t platform_adc_peripherals[] =
-// {
-//     [WICED_ADC_1] = {ADC1, ADC_Channel_1, RCC_APB2Periph_ADC1, 1, &platform_gpio_pins[WICED_GPIO_2]},
-//     [WICED_ADC_2] = {ADC1, ADC_Channel_2, RCC_APB2Periph_ADC1, 1, &platform_gpio_pins[WICED_GPIO_4]},
-//     [WICED_ADC_3] = {ADC1, ADC_Channel_3, RCC_APB2Periph_ADC1, 1, &platform_gpio_pins[WICED_GPIO_5]},
-// };
+const platform_adc_t platform_adc_peripherals[] =
+{
+    [WICED_ADC_1] = {ADC1, ADC_Channel_3, RCC_APB2Periph_ADC1, 1, &platform_gpio_pins[WICED_GPIO_5]},
+    [WICED_ADC_2] = {ADC1, ADC_Channel_4, RCC_APB2Periph_ADC1, 1, &platform_gpio_pins[WICED_GPIO_6]},
+    [WICED_ADC_3] = {ADC1, ADC_Channel_1, RCC_APB2Periph_ADC1, 1, &platform_gpio_pins[WICED_GPIO_11]},
+    [WICED_ADC_4] = {ADC1, ADC_Channel_12, RCC_APB2Periph_ADC1, 1, &platform_gpio_pins[WICED_GPIO_12]},
+    [WICED_ADC_5] = {ADC1, ADC_Channel_9, RCC_APB2Periph_ADC1, 1, &platform_gpio_pins[WICED_GPIO_16]},
+    [WICED_ADC_6] = {ADC1, ADC_Channel_0, RCC_APB2Periph_ADC1, 1, &platform_gpio_pins[WICED_GPIO_29]},
+    [WICED_ADC_7] = {ADC1, ADC_Channel_5, RCC_APB2Periph_ADC1, 1, &platform_gpio_pins[WICED_GPIO_31]},
+    [WICED_ADC_8] = {ADC1, ADC_Channel_6, RCC_APB2Periph_ADC1, 1, &platform_gpio_pins[WICED_GPIO_32]},
+    [WICED_ADC_9] = {ADC1, ADC_Channel_13, RCC_APB2Periph_ADC1, 1, &platform_gpio_pins[WICED_GPIO_35]},
+    [WICED_ADC_10] = {ADC1, ADC_Channel_14, RCC_APB2Periph_ADC1, 1, &platform_gpio_pins[WICED_GPIO_36]},
+};
 
 /* PWM peripherals. Used by WICED/platform/MCU/wiced_platform_common.c */
 const platform_pwm_t platform_pwm_peripherals[] =

--- a/patches/EMW3162/platform.h
+++ b/patches/EMW3162/platform.h
@@ -107,6 +107,13 @@ typedef enum
     WICED_ADC_1,
     WICED_ADC_2,
     WICED_ADC_3,
+    WICED_ADC_4,
+    WICED_ADC_5,
+    WICED_ADC_6,
+    WICED_ADC_7,
+    WICED_ADC_8,
+    WICED_ADC_9,
+    WICED_ADC_10,
     WICED_ADC_MAX, /* Denotes the total number of ADC port aliases. Not a valid ADC alias */
     WICED_ADC_32BIT = 0x7FFFFFFF,
 } wiced_adc_t;


### PR DESCRIPTION
Hi,

I just started playing EMW3162 and noticed that ADC was not supported in platform.c. For my project I need to measure voltage, so I added missing definitions and verified using simple program that all 10 channels work fine.
